### PR TITLE
Addition of the seed parameterin the stateNotifierTest method

### DIFF
--- a/lib/src/state_notifier_test_base.dart
+++ b/lib/src/state_notifier_test_base.dart
@@ -125,6 +125,7 @@ void stateNotifierTest<SN extends StateNotifier<State>, State>(
         verify: verify,
         errors: errors,
         tearDown: tearDown,
+        seed:seed
       );
     },
   );


### PR DESCRIPTION
The seed property was not used in the stateNotifierTest method