### PR TITLE
Added ignoreBuildCalls parameter to be able to ignore build method's additional method calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ stateNotifierTest(
 
  `build` should construct and return the `stateNotifier` under test.
 
+`ignoreBuildCalls` is a `bool` which can be used to add a short time delay if
+`stateNotifier` constructor within build method will call additional methods 
+that could interfere with the states being listened to in the test
+`ignoreBuildCalls` defaults to false.
+
  `seed` is an optional `Function` that returns a state
  which will be used to seed the `stateNotifier` before `actions` is called.
 

--- a/lib/src/state_notifier_test_base.dart
+++ b/lib/src/state_notifier_test_base.dart
@@ -18,6 +18,11 @@ import 'package:state_notifier/state_notifier.dart';
 ///
 /// [build] should construct and return the `stateNotifier` under test.
 ///
+/// [ignoreBuildCalls] is a `bool` which can be used to add a short time delay if
+/// `stateNotifier` constructor within build method will call additional methods
+/// that could interfere with the states being listened to in the test
+/// [ignoreBuildCalls] defaults to false.
+///
 /// [seed] is an optional `Function` that returns a state
 /// which will be used to seed the `stateNotifier` before [action] is called.
 ///
@@ -111,6 +116,7 @@ void stateNotifierTest<SN extends StateNotifier<State>, State>(
   State Function()? seed,
   int skip = 0,
   required SN Function() build,
+  bool ignoreBuildCalls = false,
   dynamic Function()? errors,
 }) {
   test.test(
@@ -125,7 +131,8 @@ void stateNotifierTest<SN extends StateNotifier<State>, State>(
           verify: verify,
           errors: errors,
           tearDown: tearDown,
-          seed: seed);
+          seed: seed,
+          ignoreBuildCalls: ignoreBuildCalls);
     },
   );
 }
@@ -143,12 +150,16 @@ Future<void> testNotifier<SN extends StateNotifier<State>, State>({
   dynamic Function()? errors,
   FutureOr<void> Function()? setUp,
   required int skip,
+  required bool ignoreBuildCalls,
 }) async {
   final unhandledErrors = <Object>[];
 
   await setUp?.call();
   List<State> states = <State>[];
   final stateNotifier = build();
+  if (ignoreBuildCalls) {
+    await Future.delayed(const Duration(milliseconds: 100));
+  }
 
   stateNotifier.addListener(
     (state) {


### PR DESCRIPTION
If the StateNotifier's constructor calls some method that will update the state it will interfere with the method being called directly in the actions callback of the test itself.

For example if in the StateNotifier we have a constructor and method we would like to test like below:
```  
class ExampleStateNotifier extends StateNotifier<ExampleState> {
  final ExampleRepository _recipeRepository;
  ExampleStateNotifier(this._exampleRepository)
      : super(const ExampleState.initial()) {
    loadExampleString();
  }

  Future<void> loadExampleString() async {
    state = const ExampleState.loading();
    final result = await _exampleRepository.loadExampleString();
    state = result.fold(
        (failure) => ExampleState.error(error: failure.failureMessage()),
        (data) => ExampleState.loaded(string: data.string ?? ''));
  }
}
```
Now if we want in the test to test `loadExampleString()` method, because `loadExampleString()` is also being called from the constructor we won't get expected states in the test, `ExampleState.loading()` and `ExampleState.loaded(string: string)`. By adding a short delay after `build()` method is called in the `testNotifier()` method, `loadExampleString()` call from the constructor will be ignored and then when testing `loadExampleString()` we will be able to get the exact states we are expecting. 

The proposed solution then is to add new attribute `ignoreBuildCalls` when instantiating stateNotifierTest class and adding a short delay (100 ms should be enough for testing with mock repository) after the `build()` method is being called.

If you see a different and perhaps better solution for the described problem, feel free to share it :)

Other similar solution that comes to my mind is to introduce just `afterBuild` optional Future callback that could be await executed after the `build()` call to maybe have a little bit more options in defining how long this delay should be. On the other hand `ignoreBuildCalls` attribute is maybe more clear how to use it but I would also like to hear your opinion on that.

Kind regards,
Ivan Celija